### PR TITLE
Bump metadata-proxy image to v0.1.12

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -48,7 +48,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: metadata-proxy
-        image: k8s.gcr.io/metadata-proxy:v0.1.11
+        image: k8s.gcr.io/metadata-proxy:v0.1.12
         securityContext:
           privileged: true
         # Request and limit resources to get guaranteed QoS.


### PR DESCRIPTION
Rebases the image on `gcr.io/distroless/static:latest` per kubernetes/enhancements#900:
https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190316-rebase-images-to-distroless.md

https://github.com/GoogleCloudPlatform/k8s-metadata-proxy/releases/tag/v0.1.12

/kind cleanup
/priority important-soon
/sig gcp
/assign tallclair
FYI @yuwenma

```release-note
NONE
```
